### PR TITLE
Move config out to a per project config file

### DIFF
--- a/lib/sov/foray.rb
+++ b/lib/sov/foray.rb
@@ -1,5 +1,6 @@
 require 'sov/utils/io'
 require 'sov/utils/db'
+require 'sov/utils/config'
 require 'sov/utils/branch_management'
 require 'pry'
 
@@ -13,9 +14,13 @@ class Sov::Foray
     extend Sov::Utils::DB::CLASS_METHODS
     include Sov::Utils::DB::INSTANCE_METHODS
 
+    extend Sov::Utils::Config::CLASS_METHODS
+    include Sov::Utils::Config::INSTANCE_METHODS
+
     def initialize(options={})
+      @config = get_config
       @task = options[:task]
-      @dump_dir = options[:custom_dump_dir] || Sov::Utils::DUMP_DIR
+      @dump_dir = options[:custom_dump_dir] || @config['dump_dir'] || Sov::Utils::DUMP_DIR
       @project_dir = options[:custom_project_dir] || '.'
       @verbose = options[:verbose]
       @new_branch = options[:new_branch]

--- a/lib/sov/utils/config.rb
+++ b/lib/sov/utils/config.rb
@@ -1,0 +1,35 @@
+require 'sov/utils/constants'
+require 'fileutils'
+require 'yaml'
+
+module Sov
+  module Utils
+    module Config
+      module CLASS_METHODS
+      end
+
+      module INSTANCE_METHODS
+        def initialize
+          error_out_with_message('Configuration file not present') unless File.exists?('.sov_utils.yml')
+          @config = YAML.load_file('.sov_utils.yml')
+        end
+
+        def psql_version
+          @config.fetch('psql_version')
+        end
+
+        def bundler_version
+          @config.fetch('bundler_version')
+        end
+
+        def dump_dir
+          @config.fetch('dump_dir')
+        end
+
+        def dump_max_count
+          @config.fetch('dump_max_count')
+        end
+      end
+    end
+  end
+end

--- a/lib/sov/utils/constants.rb
+++ b/lib/sov/utils/constants.rb
@@ -1,12 +1,9 @@
 #This file is used as a manifest file to easily change details such as versions when necessary
 module Sov
   module Utils
-    VERSION = '0.2.2'
-    PACKAGE_NAME = 'sov-utils'
-    PSQL_VERSION = '9.6.6'
-    BUNDLER_VERSION = '1.15.1'
+    VERSION = '1.0.0'
     PROJECT_NAME = 'sov-utils'
+    PACKAGE_NAME = 'sov-utils'
     DUMP_DIR = '.dump_files'
-    DUMP_MAX_COUNT = 10
   end
 end

--- a/lib/sov/utils/db.rb
+++ b/lib/sov/utils/db.rb
@@ -96,7 +96,7 @@ module Sov
             print_update('You are currently using the correct Postgres version.')
           else
             message = "Your current version of Postgresql is unsupported. " +
-              "#{PSQL_VERSION} is the supported version."
+              "#{@config.psql_version} is the supported version."
             error_out_with_message(message)
           end
         end
@@ -115,7 +115,7 @@ module Sov
             print_update('You are currently using the correct Bundler version.')
           else
             message = "Your current version of Bundler is unsupported. " +
-              "#{BUNDLER_VERSION} is the supported version."
+              "#{@config.bundler_version} is the supported version."
             error_out_with_message(message)
           end
         end
@@ -138,7 +138,7 @@ module Sov
             print_update('Your git ignore settings are correct.')
           else
             message = "Your git ignore settings are not correct. " +
-              "Please add #{Sov::Utils::DUMP_DIR} to the git ignore file."
+              "Please add #{@dump_dir} to the git ignore file."
             error_out_with_message(message)
           end
         end
@@ -146,10 +146,10 @@ module Sov
         def ensure_dump_files_count
           dump_count = run("ls #{@dump_dir}").split(/\n/).length
 
-          return false unless dump_count > Sov::Utils::DUMP_MAX_COUNT
+          return false unless dump_count > @config.dump_max_count
 
           print("Your system currently has #{dump_count}. " +
-                  "#{Sov::Utils::DUMP_MAX_COUNT} is the configured max.")
+                  "#{@config.dump_max_count} is the configured max.")
           print('Would you like to:')
           print('1) Do nothing')
           print('2) Clear out the directory')
@@ -202,11 +202,11 @@ module Sov
         end
 
         def pg_supported_version?
-          run('psql --version').include?(Sov::Utils::PSQL_VERSION)
+          run('psql --version').include?(@config.psql_version)
         end
 
         def bundler_supported_version?
-          run('bundle -v').include?(Sov::Utils::BUNDLER_VERSION)
+          run('bundle -v').include?(@config.bundler_version)
         end
 
         def newest_util_version?


### PR DESCRIPTION
# Overview

Some of the config in this project actually needed to be housed outside of this gem since it is elected by the project using this gem.

This PR allows that config to be housed in `.sov_utils.yml`.